### PR TITLE
chore: fixes for tflint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.5
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/versions.tf
+++ b/versions.tf
@@ -21,6 +21,14 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 4.29, < 5.0"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.29, < 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.2"
+    }
   }
 
   provider_meta "google" {


### PR DESCRIPTION
We started rolling out tflint and this fixes a few issues discovered.
```
Checking for tflint
Working in . ...
2 issue(s) found:

Warning: Missing version constraint for provider "random" in "required_providers" (terraform_required_providers)

  on main.tf line 38:
  38: resource "random_id" "deployment_id" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.1/docs/rules/terraform_required_providers.md

Warning: Missing version constraint for provider "google-beta" in "required_providers" (terraform_required_providers)

  on main.tf line 113:
 113: resource "google_project_service_identity" "bigquery_data_transfer_sa" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.1/docs/rules/terraform_required_providers.md

tflint failed . 
Working in ./examples/simple_example ...
tflint passed ./examples/simple_example 
```