### PR TITLE
chore: Add a test to verify multiple deployments in a single project

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -39,6 +39,9 @@ steps:
 - id: simple-example-teardown
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestSimpleExample --stage teardown --verbose']
+- id: multiple-deploy
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestMultipleDeploy --verbose']
 tags:
 - 'ci'
 - 'integration'

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -3,6 +3,6 @@ module github.com/terraform-google-modules/log-analysis/test/integration
 go 1.16
 
 require (
-	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.0
+	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.4.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/test/integration/go.sum
+++ b/test/integration/go.sum
@@ -67,6 +67,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.0 h1:aG9LnCzEcbJMblptKNZ5yIgPzHKCPqxZc6gmYo0n+ZQ=
 github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.0/go.mod h1:E655Ka0BfIYALBmqU9ZbemLk/nutxw4vU6wkLEjshSA=
+github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.1-0.20221202203830-f6ffa1f60039 h1:mg2mHkQ4h6gxW66CJK32WMwsyq8jRS7u2+5Lz9XxQSI=
+github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.3.1-0.20221202203830-f6ffa1f60039/go.mod h1:E655Ka0BfIYALBmqU9ZbemLk/nutxw4vU6wkLEjshSA=
+github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.4.0 h1:739vuqwRvwUbNvZltlvRZNLyjmutdc323VNCaGDEKaw=
+github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.4.0/go.mod h1:E655Ka0BfIYALBmqU9ZbemLk/nutxw4vU6wkLEjshSA=
 github.com/GoogleContainerTools/kpt-functions-sdk/go v0.0.0-20220301220754-6964a09d6cd2/go.mod h1:lJYiqfBOl6AOiefK9kmkhinbffIysu+nnclOBwKEPlQ=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/test/integration/simple_example/multiple_deploy_test.go
+++ b/test/integration/simple_example/multiple_deploy_test.go
@@ -1,0 +1,18 @@
+package simple_example
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+)
+
+func TestMultipleDeploy(t *testing.T) {
+	multipleDeployExample := tft.NewTFBlueprintTest(t)
+	// RedeployTest will first perform the init, apply, verify stages
+	// in two different TF workspaces and then teardown.
+	// No custom verification performed here as that is handled in simple example.
+	multipleDeployExample.RedeployTest(2, map[int]map[string]interface{}{
+		1: {"deployment_name": "deployment-1"},
+		2: {"deployment_name": "deployment-2"},
+	})
+}

--- a/test/integration/simple_example/simple_example_test.go
+++ b/test/integration/simple_example/simple_example_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package multiple_buckets
+package simple_example
 
 import (
 	"testing"


### PR DESCRIPTION
This uses a new helper in the test framework to deploy a blueprint multiple times within the same project to verify no resource conflicts.