### PR TITLE
fix: enable uniform bucket level access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ resource "google_storage_bucket" "ingest_bucket" {
   project  = var.project_id
   location = var.region
   labels   = var.labels
+
   uniform_bucket_level_access = true
 }
 

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ resource "google_storage_bucket" "ingest_bucket" {
   project  = var.project_id
   location = var.region
   labels   = var.labels
+  uniform_bucket_level_access = true
 }
 
 // Copy a sample file to the bucket created


### PR DESCRIPTION
As written, the repo can't deploy into an environment configured for Google-recommended security practices due to the GCS bucket not configuring uniform bucket level access. This is good security practice and reduces compatibility issues with other google frameworks.